### PR TITLE
add support for domain token

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,6 +19,9 @@ type Client struct {
 	// User Email
 	Email string
 
+	// Domain Token
+	DomainToken string
+
 	// URL to the DO API to use
 	URL string
 
@@ -57,6 +60,15 @@ func NewClient(email string, token string) (*Client, error) {
 	return &client, nil
 }
 
+func NewClientWithDomainToken(domainToken string) (*Client, error) {
+	client := Client{
+		DomainToken: domainToken,
+		URL:         "https://api.dnsimple.com/v1",
+		Http:        http.DefaultClient,
+	}
+	return &client, nil
+}
+
 // Creates a new request with the params
 func (c *Client) NewRequest(body map[string]interface{}, method string, endpoint string) (*http.Request, error) {
 	u, err := url.Parse(c.URL + endpoint)
@@ -77,7 +89,11 @@ func (c *Client) NewRequest(body map[string]interface{}, method string, endpoint
 	}
 
 	// Add the authorization header
-	req.Header.Add("X-DNSimple-Token", fmt.Sprintf("%s:%s", c.Email, c.Token))
+	if c.DomainToken != "" {
+		req.Header.Add("X-DNSimple-Domain-Token", c.DomainToken)
+	} else {
+		req.Header.Add("X-DNSimple-Token", fmt.Sprintf("%s:%s", c.Email, c.Token))
+	}
 	req.Header.Add("Accept", "application/json")
 
 	// If it's a not a get, add a content-type

--- a/api_test.go
+++ b/api_test.go
@@ -18,6 +18,20 @@ func makeClient(t *testing.T) *Client {
 	return client
 }
 
+func makeClientWithDomainToken(t *testing.T) *Client {
+	client, err := NewClientWithDomainToken("foobardomaintoken")
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if client.DomainToken != "foobardomaintoken" {
+		t.Fatalf("domian token not set on client: %s", client.DomainToken)
+	}
+
+	return client
+}
+
 func TestClient_NewRequest(t *testing.T) {
 	c := makeClient(t)
 
@@ -35,6 +49,31 @@ func TestClient_NewRequest(t *testing.T) {
 	}
 
 	if req.Header.Get("X-DNSimple-Token") != "foobaremail:foobartoken" {
+		t.Fatalf("bad auth header: %v", req.Header)
+	}
+
+	if req.Method != "POST" {
+		t.Fatalf("bad method: %v", req.Method)
+	}
+}
+
+func TestClientDomainToken_NewRequest(t *testing.T) {
+	c := makeClientWithDomainToken(t)
+
+	body := map[string]interface{}{
+		"foo": "bar",
+		"baz": "bar",
+	}
+	req, err := c.NewRequest(body, "POST", "/bar")
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	if req.URL.String() != "https://api.dnsimple.com/v1/bar" {
+		t.Fatalf("bad base url: %v", req.URL.String())
+	}
+
+	if req.Header.Get("X-DNSimple-Domain-Token") != "foobardomaintoken" {
 		t.Fatalf("bad auth header: %v", req.Header)
 	}
 


### PR DESCRIPTION
I need to be able to use a domain token instead of the email/token pair in terraform, so I added support to this library. It's not very DRY but it should work without breaking anything existing. We can refactor a bit if you don't like how much it repeats.

ping @pearkes for review, thanks!