### PR TITLE
add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+
+go:
+  - 1.3
+  - tip


### PR DESCRIPTION
This ads the travis config file necessary to run tests on Travis CI. This branch passes CI as seen here: https://travis-ci.org/dwradcliffe/dnsimple/builds/65642553.