### PR TITLE
Return the parse error if parsing of the TTL parameter failed

### DIFF
--- a/record.go
+++ b/record.go
@@ -64,7 +64,7 @@ func (c *Client) CreateRecord(domain string, opts *ChangeRecord) (string, error)
 	if opts.Ttl != "" {
 		ttl, err := strconv.ParseInt(opts.Ttl, 0, 0)
 		if err != nil {
-			return "", nil
+			return "", fmt.Errorf("Error parsing ttl: %s", err.Error())
 		}
 		params["ttl"] = ttl
 	}
@@ -114,7 +114,7 @@ func (c *Client) UpdateRecord(domain string, id string, opts *ChangeRecord) (str
 	if opts.Ttl != "" {
 		ttl, err := strconv.ParseInt(opts.Ttl, 0, 0)
 		if err != nil {
-			return "", nil
+			return "", fmt.Errorf("Error parsing ttl: %s", err.Error())
 		}
 		params["ttl"] = ttl
 	}


### PR DESCRIPTION
I ran into an issue yesterday because the `CreateRecord` and `UpdateRecord` functions swallowed a parse error that was caused by an invalid value for the `Ttl` that I passed in with the `ChangeRecord`.

My call to UpdateRecord didn't go through and I didn't know why. And because the functions did not return an error it took me a while to find my mistake.

It would be nice if you could merge this small change.

Greetings
Andy
