### PR TITLE
Allow record priority to be specified when creating and updating

### DIFF
--- a/record.go
+++ b/record.go
@@ -48,6 +48,7 @@ type ChangeRecord struct {
 	Value string // where the record points
 	Type  string // type, i.e a, mx
 	Ttl   string // TTL of record
+	Prio  string // Priority of record - only relevant for some record types
 }
 
 // CreateRecord creates a record from the parameters specified and
@@ -67,6 +68,14 @@ func (c *Client) CreateRecord(domain string, opts *ChangeRecord) (string, error)
 			return "", nil
 		}
 		params["ttl"] = ttl
+	}
+
+	if opts.Prio != "" {
+		prio, err := strconv.ParseInt(opts.Prio, 0, 0)
+		if err != nil {
+			return "", fmt.Errorf("Error parsing prio: %s", err.Error())
+		}
+		params["prio"] = prio
 	}
 
 	endpoint := fmt.Sprintf("/domains/%s/records", domain)
@@ -117,6 +126,14 @@ func (c *Client) UpdateRecord(domain string, id string, opts *ChangeRecord) (str
 			return "", nil
 		}
 		params["ttl"] = ttl
+	}
+
+	if opts.Prio != "" {
+		prio, err := strconv.ParseInt(opts.Prio, 0, 0)
+		if err != nil {
+			return "", fmt.Errorf("Error parsing prio: %s", err.Error())
+		}
+		params["prio"] = prio
 	}
 
 	endpoint := fmt.Sprintf("/domains/%s/records/%s", domain, id)

--- a/record_test.go
+++ b/record_test.go
@@ -39,6 +39,8 @@ func (s *S) Test_CreateRecord(c *C) {
 
 	opts := ChangeRecord{
 		Name: "foobar",
+		Ttl:  "300",
+		Prio: "10",
 	}
 
 	id, err := s.client.CreateRecord("example.com", &opts)
@@ -54,6 +56,8 @@ func (s *S) Test_UpdateRecord(c *C) {
 
 	opts := ChangeRecord{
 		Name: "foobar",
+		Ttl:  "300",
+		Prio: "10",
 	}
 
 	id, err := s.client.UpdateRecord("example.com", "25", &opts)


### PR DESCRIPTION
Some record types (like MX) allow a priority to be specified, and it's useful to have the option to provide it.

Like ttl, the prio param is optional so I've emulated that way ttl is parsed and handled.

I've also added Ttl and Prio to the test cases to ensure conditional code is executed.
